### PR TITLE
Add support for Tilesets and Tilemap layers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ aseFile.parse();
 | tags         | arry of [tag](#tag-object) objects    | tags                                   |
 | colorProfile | [colorProfile](#color-profile-object) object    | Color profile                          |
 | palette      | [palette](#palette-object) object         | Palette                                |
+| tilesets     | array of [tileset](#tileset-object) objects | Tileset                                |
 | slices       | array of [slice](#slice-object) objects | Info on slices |
 
 ## Frame Object
@@ -140,13 +141,14 @@ aseFile.parse();
 | cels          | array of [cel](#cel-object) objects | cels             |
 
 ## Layer Object
-| Field           | Type    | Description         |
-|-----------------|---------|---------------------|
-| flags           | integer | flags for the layer |
-| type            | integer | type                |
-| layerChildLevel | integer | layer child level   |
-| opacity         | integer | opacity (0-255)     |
-| name            | string  | name of layer       |
+| Field           | Type    | Description                   |
+|-----------------|---------|-------------------------------|
+| flags           | integer | flags for the layer           |
+| type            | integer | type                          |
+| layerChildLevel | integer | layer child level             |
+| opacity         | integer | opacity (0-255)               |
+| tilesetIndex?   | integer | the tileset id, if applicable |
+| name            | string  | name of layer                 |
 
 
 ## Tag Object
@@ -175,17 +177,44 @@ aseFile.parse();
 | colors      | array of [color](#color-object) objects | colors                   |
 | index?      | integer                | position of the indexed color based on the palette |
 
+## Tileset Object
+| Field           | Type                   | Description                |
+|-----------------|------------------------|----------------------------|
+| id              | integer                | tileset id number          |
+| tileCount       | integer                | number of tiles            |
+| tileWidth       | integer                | pixel width of each tile   |
+| tileHeight      | integer                | pixel height ofeach tile   |
+| name            | string                 | name                       |
+| externalFile?   | [tileset external file](#tileset-external-file-object) object | external file linkage info, if applicable |
+| rawTilesetData? | Buffer | raw pixel data for tiles, if applicable |
+
+## Tileset External File Object
+| Field     | Type    | Description                               |
+|-----------|---------|-------------------------------------------|
+| id        | integer | id of the external file                   |
+| tilesetId | integer | id of the tileset in the external file    |
+
 ## Cel Object
-| Field      | Type    | Description                                  |
-|------------|---------|----------------------------------------------|
-| layerIndex | integer | index of the layer associated                |
-| xpos       | integer | x position of the cel compared to the sprite |
-| ypos       | integer | y position of the cel compared to the sprite |
-| opacity    | integer | opacity (0-255)                              |
-| celType    | integer | internally used                              |
-| w          | integer | width (in pixels)                            |
-| h          | integer | height (in pixels)                           |
-| rawCelData | Buffer  | raw cel pixel data                           |
+| Field            | Type    | Description                                  |
+|------------------|---------|----------------------------------------------|
+| layerIndex       | integer | index of the layer associated                |
+| xpos             | integer | x position of the cel compared to the sprite |
+| ypos             | integer | y position of the cel compared to the sprite |
+| opacity          | integer | opacity (0-255)                              |
+| celType          | integer | internally used                              |
+| w                | integer | width (in pixels)                            |
+| h                | integer | height (in pixels)                           |
+| tilemapMetadata? | [tilemap metadata](#tileset-external-file-object) object | tilemap metadata, if applicable |
+| rawCelData       | Buffer  | raw cel pixel data                           |
+
+## Tilemap Metadata Object
+| Field                  | Type    | Description                                             |
+|------------------------|---------|---------------------------------------------------------|
+| bitsPerTile            | integer | number of bits used to represent each tile (usually 32) |
+| bitmaskForTileId       | integer | which bit(s) represent the tile ID                      |
+| bitmaskForXFlip        | integer | which bit(s) indicate X-axis flip                       |
+| bitmaskForYFlip        | integer | which bit(s) indicate Y-axis flip                       |
+| bitmaskFor90CWRotation | integer | which bit(s) indicate 90-degree clockwise rotation flip |
 
 ## Color Object
 | Field | Type    | Description                                   |

--- a/typings/Aseprite.d.ts
+++ b/typings/Aseprite.d.ts
@@ -86,7 +86,7 @@ declare namespace Aseprite {
     blendMode: number;
     opacity: number;
     name: string;
-    tilesetIndex: number | undefined;
+    tilesetIndex?: number;
   }
   export interface Slice {
     flags: number;

--- a/typings/Aseprite.d.ts
+++ b/typings/Aseprite.d.ts
@@ -4,6 +4,7 @@ declare class Aseprite {
   slices: Array<Aseprite.Slice>;
   tags: Array<Aseprite.Tag>;
   palette: Aseprite.Palette;
+  tilesets: Array<Aseprite.Tileset>;
   colorProfile: Aseprite.ColorProfile;
   name: string;
   paletteIndex: number;
@@ -35,6 +36,18 @@ declare namespace Aseprite {
     colors: Array<Color>;
     index?: number;
   }
+  export interface Tileset {
+    id: number;
+    tileCount: number;
+    tileWidth: number;
+    tileHeight: number;
+    name: string;
+    externalFile?: {
+      id: number;
+      tilesetId: number;
+    };
+    rawTilesetData?: Buffer;
+  }
   export interface Color {
     red: number;
     green: number;
@@ -50,6 +63,13 @@ declare namespace Aseprite {
     celType: number;
     w: number;
     h: number;
+    tilemapMetadata?: {
+      bitsPerTile: number;
+      bitmaskForTileId: number;
+      bitmaskForXFlip: number;
+      bitmaskForYFlip: number;
+      bitmaskFor90CWRotation: number;
+    };
     rawCelData: Buffer;
   }
   export interface Tag {
@@ -66,6 +86,7 @@ declare namespace Aseprite {
     blendMode: number;
     opacity: number;
     name: string;
+    tilesetIndex: number | undefined;
   }
   export interface Slice {
     flags: number;


### PR DESCRIPTION
These features are new in Aseprite 1.3, and with this
in place, then `.aseprite` becomes a viable format for
making 2D game maps that get loaded in the browser
after being parsed by this library.