### PR TITLE
Add support for linked cel type

### DIFF
--- a/typings/Aseprite.d.ts
+++ b/typings/Aseprite.d.ts
@@ -48,6 +48,7 @@ declare namespace Aseprite {
     ypos: number;
     opacity: number;
     celType: number;
+    link?: number;
     w: number;
     h: number;
     rawCelData: Buffer;


### PR DESCRIPTION
It appears that linked cel types were just treated as regular raw or compressed cels, while the Aseprite format spec states that their data is slightly different. This would lead to errors while trying to parse files with linked cels on any layers because it would try to read a buffer of invalid size.

This change adds support for linked cels by parsing their format properly. Linked cels then reference size and raw data of their linked frame after all frames have been parsed to avoid potentially linking to a frame that hasn't been parsed yet.