### PR TITLE
Fix possible out of range read when ICC color profile is present

### DIFF
--- a/Aseprite.js
+++ b/Aseprite.js
@@ -167,7 +167,11 @@ class Aseprite {
     const flag = this.readNextWord();
     const fGamma = this.readNextFixed();
     this.skipBytes(8);
-    //handle ICC profile data
+    if (typeInd === 2) {
+      //TODO: Handle ICC profile data properly instead of skipping
+      const skip = this.readNextDWord();
+      this.skipBytes(skip);
+    }
     this.colorProfile = {
       type,
       flag,


### PR DESCRIPTION
Files with embedded ICC profiles could cause issues in some cases, as their profile chunk wasn't parsed properly.
This would lead to an out of bounds read beyond the file end. Not every file seems to cause this problem, so I've attached a file that causes said error. 

[icc_test.zip](https://github.com/TheCyberRonin/ase-parser/files/10027009/icc_test.zip)

This change fixes the parsing of color profile chunks, which previously didn't properly skip over embedded ICC profile data if it was present.
