### PR TITLE
Add support for Aseprite 1.3 fields

### DIFF
--- a/Aseprite.js
+++ b/Aseprite.js
@@ -528,7 +528,8 @@ class Aseprite {
     const y = this.readNextShort();
     const opacity = this.readNextByte();
     const celType = this.readNextWord();
-    this.skipBytes(7);
+    const zIndex = this.readNextShort();
+    this.skipBytes(5);
     if (celType === 1) {
       return {
         layerIndex,
@@ -536,6 +537,7 @@ class Aseprite {
         ypos: y,
         opacity,
         celType,
+        zIndex,
         w: 0,
         h: 0,
         rawCelData: undefined,
@@ -544,7 +546,16 @@ class Aseprite {
     }
     const w = this.readNextWord();
     const h = this.readNextWord();
-    const chunkBase = { layerIndex, xpos: x, ypos: y, opacity, celType, w, h };
+    const chunkBase = {
+      layerIndex,
+      xpos: x,
+      ypos: y,
+      opacity,
+      celType,
+      zIndex,
+      w,
+      h
+    };
     if (celType === 0 || celType === 2) {
       const buff = this.readNextRawBytes(chunkSize - 26); // take the first 20 bytes off for the data above and chunk info
       return {

--- a/Aseprite.js
+++ b/Aseprite.js
@@ -530,36 +530,31 @@ class Aseprite {
     const celType = this.readNextWord();
     this.skipBytes(7);
     if (celType === 1) {
-      return { layerIndex,
-          xpos: x,
-          ypos: y,
-          opacity,
-          celType,
-          w: 0,
-          h: 0,
-          rawCelData: undefined,
-          link: this.readNextWord()
+      return {
+        layerIndex,
+        xpos: x,
+        ypos: y,
+        opacity,
+        celType,
+        w: 0,
+        h: 0,
+        rawCelData: undefined,
+        link: this.readNextWord()
       };
     }
     const w = this.readNextWord();
     const h = this.readNextWord();
     const chunkBase = { layerIndex, xpos: x, ypos: y, opacity, celType, w, h };
     if (celType === 0 || celType === 2) {
-      return { ...chunkBase, ...this.readImageCelChunk(chunkSize) }
+      const buff = this.readNextRawBytes(chunkSize - 26); // take the first 20 bytes off for the data above and chunk info
+      return {
+        ...chunkBase,
+        rawCelData: celType === 2 ? zlib.inflateSync(buff) : buff
+      }
     }
     if (celType === 3) {
       return { ...chunkBase, ...this.readTilemapCelChunk(chunkSize) }
     }
-  }
-  readImageCelChunk(chunkSize) {
-    const buff = this.readNextRawBytes(chunkSize - 26); //take the first 20 bytes off for the data above and chunk info
-    let rawCel;
-    if(celType === 2) {
-      rawCel = zlib.inflateSync(buff);
-    } else if(celType === 0) {
-      rawCel = buff;
-    }
-    return { rawCelData: rawCel };
   }
   readTilemapCelChunk(chunkSize) {
     const bitsPerTile = this.readNextWord();

--- a/Aseprite.js
+++ b/Aseprite.js
@@ -346,7 +346,8 @@ class Aseprite {
     const loops = [
       'Forward',
       'Reverse',
-      'Ping-pong'
+      'Ping-pong',
+      'Ping-pong Reverse'
     ]
     const numTags = this.readNextWord();
     this.skipBytes(8);
@@ -356,7 +357,8 @@ class Aseprite {
       tag.to = this.readNextWord();
       const loopsInd = this.readNextByte();
       tag.animDirection = loops[loopsInd];
-      this.skipBytes(8);
+      tag.repeat = this.readNextWord();
+      this.skipBytes(6);
       tag.color = this.readNextRawBytes(3).toString('hex');
       this.skipBytes(1);
       tag.name = this.readNextString();

--- a/README.md
+++ b/README.md
@@ -44,7 +44,15 @@ async function makePNG() {
   }}).png().toBuffer();
   
   // Get the cels for the first frame
-  const cels = ase.frames[0].cels;
+  const cels = ase.frames[0].cels
+    // copy the array
+    .map(a => a)
+    .sort((a, b) => {
+      const orderA = a.layerIndex + a.zIndex;
+      const orderB = b.layerIndex + b.zIndex;
+      // sort by order, then by zIndex
+      return orderA - orderB || a.zIndex - b.zIndex;
+    })
   
   // Create png image buffers per cel to create an image of the first frame (creating the Promises to be used)
   const otherPromises = cels.map(cel => {
@@ -203,6 +211,7 @@ aseFile.parse();
 | ypos             | integer | y position of the cel compared to the sprite |
 | opacity          | integer | opacity (0-255)                              |
 | celType          | integer | internally used                              |
+| zIndex           | integer | show this cel N layers later/back            |
 | w                | integer | width (in pixels)                            |
 | h                | integer | height (in pixels)                           |
 | tilemapMetadata? | [tilemap metadata](#tileset-external-file-object) object | tilemap metadata, if applicable |

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ aseFile.parse();
 |---------------|---------|----------------------------------------|
 | from          | integer | first frame index                    |
 | to            | integer | last frame index                     |
-| animDirection | string  | `Forward`, `Reverse` or `Ping-pong`    |
+| animDirection | string  | `Forward`, `Reverse`, `Ping-pong` or `Ping-pong Reverse` |
+| repeat        | integer | repeat animation N times               |
 | color         | string  | hex color of the tag (no `#` included) |
 | name          | string  | name                                   |
 

--- a/typings/Aseprite.d.ts
+++ b/typings/Aseprite.d.ts
@@ -78,6 +78,7 @@ declare namespace Aseprite {
     from: number;
     to: number;
     animDirection: string;
+    repeat: number;
     color: string;
   }
   export interface Layer {

--- a/typings/Aseprite.d.ts
+++ b/typings/Aseprite.d.ts
@@ -61,6 +61,7 @@ declare namespace Aseprite {
     ypos: number;
     opacity: number;
     celType: number;
+    zIndex: number;
     link?: number;
     w: number;
     h: number;


### PR DESCRIPTION
Hey!

This PR:
* adds support the repeat field and ping-pong reverse animation direction (https://github.com/aseprite/aseprite/commit/4f96d37b1f9f91d7b2dc73e5d5fcf6e03b291823)
* adds support for zIndex (https://github.com/aseprite/aseprite/commit/24846eae10c7340a4e7f103b15494ea8338700a9, https://github.com/aseprite/aseprite/commit/943f0df625957524649f72804f4573b5e66d8b74)
* fixes a runtime error I encountered on the master branch (inlining the function felt more natural to me than adding another parameter, but I can change that if you want)